### PR TITLE
Added functionality to display extra links in navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The following customizations are available by editing `user/config/themes/webfol
 - **Custom Logo** (`custom_logo`) - A logo image to be placed on the left side of the header throughout the site.
 - **Mobile Cusom Logo** (`custom_logo_mobile`) - A logo image to be placed at the top left of the navigation overlay on smaller screens. Note that this logo will appear on a dark background.
 - **Favicon** (`favicon`) - A small image to be used as the icon for your site in the browser.
+- **Extra Navigation Links** (`external_links`) - A list of links to be shown on the navigation menu after page and site navigation links. Can be toggled on or off by setting the value for `show_external_links` as `true` or `false`.
 - **Show Credit in Footer** (`footer_credit`) - Whether or not to display a sentence in your site footer giving credit to this theme and to Grav.
 - **Footer Links** (`footer_links`) - A list of links to be shown in the footer of every page. Each link has a `link` (URL) property and a `icon` (Font Awesome icon classes, such as `fas fa-envelope`) property.
 - **Copyright** - Include any of these fields to show a copyright notice in your site's footer.

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -52,7 +52,7 @@ form:
 
     show_external_links:
       type: toggle
-      label: Show External Links in Navbar
+      label: Show Extra Links in Navbar
       highlight: 0
       default: 0
       options:
@@ -64,7 +64,7 @@ form:
     external_links:
       type: list
       style: horizontal
-      label: External Links
+      label: Extra Links
       fields:
         .text:
           type: text

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -65,6 +65,7 @@ form:
       type: list
       style: horizontal
       label: Extra Links
+      description: Additional links to be shown in the navigation menu.
       fields:
         .text:
           type: text

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -50,6 +50,30 @@ form:
       accept:
         - image/png
 
+    show_external_links:
+      type: toggle
+      label: Show External Links in Navbar
+      highlight: 0
+      default: 0
+      options:
+        1: PLUGIN_ADMIN.YES
+        0: PLUGIN_ADMIN.NO
+      validate:
+        type: bool
+
+    external_links:
+      type: list
+      style: horizontal
+      label: External Links
+      fields:
+        .text:
+          type: text
+          label: Text
+        .link:
+          type: text
+          label: URL
+          description: Links are relative unless <tt style="color: crimson;">http://</tt> or <tt style="color: crimson;">https://</tt> is added to the link.
+
     footer_credit:
       type: toggle
       label: Show Credit in Footer

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -65,7 +65,7 @@ form:
       type: list
       style: horizontal
       label: Extra Links
-      description: Additional links to be shown in the navigation menu.
+      help: Additional links to be shown in the navigation menu.
       fields:
         .text:
           type: text

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -53,6 +53,7 @@ form:
     show_external_links:
       type: toggle
       label: Show Extra Links in Navigation Menu
+      description: Additional links to be shown in the navigation menu.
       highlight: 0
       default: 0
       options:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -73,7 +73,7 @@ form:
         .link:
           type: text
           label: URL
-          description: Links are relative unless <tt style="color: crimson;">http://</tt> or <tt style="color: crimson;">https://</tt> is added to the link.
+          description: Links are relative unless the protocol (e.g., <tt style="color: crimson;">https://</tt>) is included.
 
     footer_credit:
       type: toggle

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -52,7 +52,7 @@ form:
 
     show_external_links:
       type: toggle
-      label: Show Extra Links in Navbar
+      label: Show Extra Links in Navigation Menu
       highlight: 0
       default: 0
       options:

--- a/templates/macros/macros.html.twig
+++ b/templates/macros/macros.html.twig
@@ -45,3 +45,13 @@
       <i class="{{ icon_classes }}"></i>
   </a>
 {% endmacro %}
+
+{% macro link_loop(show_links, links) %}
+  {% if show_links %}
+    {% for l in links %}
+      <li>        
+        <a href="{{ l.link }}">{{ l.text }}</a>
+      </li>
+    {% endfor %}
+  {% endif %}
+{% endmacro %}

--- a/templates/partials/nav.html.twig
+++ b/templates/partials/nav.html.twig
@@ -3,5 +3,5 @@
 <ul class="navigation">
     {{ macros.nav_loop(pages.children, false, false) }}
     
-    {{ macros.link_loop(theme_var('show_external_links'), theme_var('external_links')) }}
+    {{ macros.link_loop(config.theme.show_external_links, config.theme.external_links) }}
 </ul>

--- a/templates/partials/nav.html.twig
+++ b/templates/partials/nav.html.twig
@@ -2,4 +2,6 @@
 
 <ul class="navigation">
     {{ macros.nav_loop(pages.children, false, false) }}
+    
+    {{ macros.link_loop(theme_var('show_external_links'), theme_var('external_links')) }}
 </ul>


### PR DESCRIPTION
I have added some code which allow users to add extra links in the navbar, by adding some fields in the blueprints.yaml file for the theme.
Items added:
- One toggle field to enable/disable this functionality (defaults to NO)
- One grav-admin list field to allow users to add multiple links and corresponding text

To add this, I had to add a macro to macros.html.twig to generate html links as list fields, and add the macro to nav.html.twig. Do check and see if this is something that is useful as a feature to be included in the base theme. I have attached a couple images to show the changes that I have made as well.
![Theme page](https://user-images.githubusercontent.com/6966900/68045054-a9130700-fcfe-11e9-9672-d59ee50ccb5e.png)

![Navbar](https://user-images.githubusercontent.com/6966900/68045109-c516a880-fcfe-11e9-919b-ad56ea8e66f0.png)

